### PR TITLE
Repeated NA check results in error

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -406,6 +406,9 @@ check_terms <- function(dataset, records, path=NULL, group="", check="all") {
 			if (!is.null(dataset$treatment_vars)) {
 				answ <- check_exp(answ, dataset$treatment_vars, dataset$data_type, names(records))
 			}
+		  else {
+		    stop("treatment_vars is required in the metadata")
+		  }
 		}
 	}
 	if (!missing(records)) {

--- a/R/check.R
+++ b/R/check.R
@@ -338,9 +338,9 @@ check_d_terms <- function(answ, x, path, type, group, check) {
 			if (length(provided) > 0) {
 				if (!is.null(voc$multiple_allowed)) {
 					if (voc$multiple_allowed[i] == "yes") {
-						if (!is.na(provided)) {
+						# if (!is.na(provided)) {
 							provided <- unlist(strsplit(provided, ";|; "))
-						}
+						# }
 					}
 				}
 				if (voc$NAok[i]=="yes") {


### PR DESCRIPTION
## Feel free to reject...

We were testing a dataset which resulted in this error message:
```
Error in if (!is.na(provided)) { : the condition has length > 1
```
Checking it seemed to come from [L341](https://github.com/reagro/carobiner/blob/master/R/check.R#L341) of [check.R](https://github.com/reagro/carobiner/blob/master/R/check.R) particularly this condition: 

```
if (!is.na(provided)) {
	provided <- unlist(strsplit(provided, ";|; "))
}
```

There seems to be already a `na.omit()` few lines before ([L336](https://github.com/reagro/carobiner/blob/master/R/check.R#L336)), and after removing the condition on [L341](https://github.com/reagro/carobiner/blob/master/R/check.R#L341) things seem to work.

My overall thinking is that the `na.omit()` already removes `NA` values from the `provided` variable, so the `!is.na()` check is not so relevant. I still cannot understand the error fully and why it indicates the `length > 1` (!?!?).

 **I haven't tested extensively**, and there are probably instances where the `!is.na()` check is granted.
